### PR TITLE
fix: Add configuration option for commit author email

### DIFF
--- a/repository-template/config.go
+++ b/repository-template/config.go
@@ -13,10 +13,11 @@ type Config struct {
 }
 
 type Client struct {
-	GitHubClient     *github.Client
-	GitHubGitAuth    transport.AuthMethod
-	CommitMessage    string
-	CommitAuthorName string
+	GitHubClient      *github.Client
+	GitHubGitAuth     transport.AuthMethod
+	CommitAuthorEmail string
+	CommitAuthorName  string
+	CommitMessage     string
 }
 
 func (c *Config) NewClient() *Client {

--- a/repository-template/provider.go
+++ b/repository-template/provider.go
@@ -8,6 +8,11 @@ import (
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
+			"commit_author_email": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Author email to use when signing commits",
+			},
 			"commit_author_name": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
@@ -41,8 +46,9 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 
 	client := config.NewClient()
 
-	client.CommitMessage = d.Get("commit_message").(string)
+	client.CommitAuthorEmail = d.Get("commit_author_email").(string)
 	client.CommitAuthorName = d.Get("commit_author_name").(string)
+	client.CommitMessage = d.Get("commit_message").(string)
 
 	return client, nil
 }

--- a/repository-template/resource_repository-template_github.go
+++ b/repository-template/resource_repository-template_github.go
@@ -175,8 +175,9 @@ func resourceRepositoryTemplateGitHubUpdate(d *schema.ResourceData, meta interfa
 		_, commitErr := worktree.Commit(client.CommitMessage, &git.CommitOptions{
 			All: false,
 			Author: &object.Signature{
-				Name: client.CommitAuthorName,
-				When: time.Now(),
+				Email: client.CommitAuthorEmail,
+				Name:  client.CommitAuthorName,
+				When:  time.Now(),
 			},
 		})
 


### PR DESCRIPTION
A commit author email is needed for pull requests to be mergeable within 
the GitHub GUI